### PR TITLE
Fixed to the content extracted from the entire document

### DIFF
--- a/lib/jekyll-auto-image.rb
+++ b/lib/jekyll-auto-image.rb
@@ -82,7 +82,7 @@ module Jekyll
       # I know, it's not efficient, but rather easy to implement :)
       
       if page.class == Jekyll::Document # for jekyll 3.0 posts & collections
-        htmled = Jekyll::Renderer.new(@site, page, @site.site_payload).run
+        htmled = Jekyll::Renderer.new(@site, page, @site.site_payload).convert(page.content)
       else 
         htmled = page.transform # for jekyll 2.x pages
       end


### PR DESCRIPTION
Thank you during this time of the bug fixes. https://github.com/merlos/jekyll-auto-image/issues/2

But there was still a problem.
Searched had become the image of the entire document.
So, it was modified to get the inside of the image of the content.

Instead `Jekyll::Renderer#run`, I was using the `Jekyll::Renderer#convert`.
